### PR TITLE
Fixed problem with low number of polygons in navmesh

### DIFF
--- a/lib/Navigation.js
+++ b/lib/Navigation.js
@@ -15,12 +15,12 @@ var BABYLON = require("babylonjs");
  */
 
 var Navigation = Class.$extend({
-  __init__: function() {
+  __init__: function () {
     this.zoneNodes = {};
     this.astar = new Astar();
   },
 
-  buildNodes: function(mesh) {
+  buildNodes: function (mesh) {
     var navigationMesh = this._buildNavigationMesh(mesh.geometry);
 
     var zoneNodes = this._groupNavMesh(navigationMesh);
@@ -28,11 +28,11 @@ var Navigation = Class.$extend({
     return zoneNodes;
   },
 
-  setZoneData: function(zone, data) {
+  setZoneData: function (zone, data) {
     this.zoneNodes[zone] = data;
   },
 
-  getGroup: function(zone, position) {
+  getGroup: function (zone, position) {
 
     if (!this.zoneNodes[zone]) {
       return null;
@@ -42,8 +42,8 @@ var Navigation = Class.$extend({
 
     var distance = Infinity;
 
-    _.each(this.zoneNodes[zone].groups, function(group, index) {
-      _.each(group, function(node) {
+    _.each(this.zoneNodes[zone].groups, function (group, index) {
+      _.each(group, function (node) {
         var measuredDistance = BABYLON.Vector3.DistanceSquared(node.centroid, position);
         if (measuredDistance < distance) {
           closestNodeGroup = index;
@@ -55,7 +55,7 @@ var Navigation = Class.$extend({
     return closestNodeGroup;
   },
 
-  getRandomNode: function(zone, group, nearPosition, nearRange) {
+  getRandomNode: function (zone, group, nearPosition, nearRange) {
 
     if (!this.zoneNodes[zone]) return new BABYLON.Vector3();
 
@@ -66,7 +66,7 @@ var Navigation = Class.$extend({
 
     var polygons = this.zoneNodes[zone].groups[group];
 
-    _.each(polygons, function(p) {
+    _.each(polygons, function (p) {
       if (nearPosition && nearRange) {
         if (BABYLON.Vector3.DistanceSquared(nearPosition, p.centroid) < nearRange * nearRange) {
           candidates.push(p.centroid);
@@ -79,7 +79,7 @@ var Navigation = Class.$extend({
     return _.sample(candidates) || new BABYLON.Vector3();
   },
 
-  projectOnNavmesh: function(position, zone, group) {
+  projectOnNavmesh: function (position, zone, group) {
     var allNodes = this.zoneNodes[zone].groups[group];
     var vertices = this.zoneNodes[zone].vertices;
 
@@ -109,13 +109,13 @@ var Navigation = Class.$extend({
   },
 
   _projectPointOnPlane: function (point, plane) {
-      var coef = BABYLON.Vector3.Dot(point, plane.normal) + plane.d;
-      var proj = point.subtract(plane.normal.scale(coef));
+    var coef = BABYLON.Vector3.Dot(point, plane.normal) + plane.d;
+    var proj = point.subtract(plane.normal.scale(coef));
 
-      return proj;
+    return proj;
   },
 
-  _getProjectionOnNode: function(position, node, vertices) {
+  _getProjectionOnNode: function (position, node, vertices) {
 
     var A = this.getVectorFrom(vertices, node.vertexIds[0]);
     var B = this.getVectorFrom(vertices, node.vertexIds[1]);
@@ -131,7 +131,7 @@ var Navigation = Class.$extend({
     var p = this._projectPointOnPlane(position, plane);
     // Compute barycentric coordinates (u, v, w) for
     // point p with respect to triangle (a, b, c)
-    var barycentric = function(p, a, b, c) {
+    var barycentric = function (p, a, b, c) {
       var ret = {};
 
       var v0 = c.subtract(a),
@@ -167,7 +167,7 @@ var Navigation = Class.$extend({
     return proj;
   },
 
-  findPath: function(startPosition, targetPosition, zone, group) {
+  findPath: function (startPosition, targetPosition, zone, group) {
 
     var allNodes = this.zoneNodes[zone].groups[group];
     var vertices = this.zoneNodes[zone].vertices;
@@ -175,22 +175,21 @@ var Navigation = Class.$extend({
     var closestNode = null;
     var distance = Infinity;
 
-    allNodes.forEach(function(node) {
+    allNodes.forEach(function (node) {
       var measuredDistance = BABYLON.Vector3.DistanceSquared(node.centroid, startPosition);
-      if (measuredDistance < distance) {
+      if (measuredDistance < distance && this._isVectorInPolygon(startPosition, node, vertices)) {
         closestNode = node;
         distance = measuredDistance;
       }
-    });
+    }.bind(this));
 
 
     var farthestNode = null;
     distance = Infinity;
 
-    allNodes.forEach(function(node) {
+    allNodes.forEach(function (node) {
       var measuredDistance = BABYLON.Vector3.DistanceSquared(node.centroid, targetPosition);
-      if (measuredDistance < distance &&
-        this._isVectorInPolygon(targetPosition, node, vertices)) {
+      if (measuredDistance < distance && this._isVectorInPolygon(targetPosition, node, vertices)) {
         farthestNode = node;
         distance = measuredDistance;
       }
@@ -201,9 +200,15 @@ var Navigation = Class.$extend({
       return null;
     }
 
-    var paths = this.astar.search(allNodes, closestNode, farthestNode);
+    if (closestNode.id != farthestNode.id) { // if the starting node and target node are at the same polygon skip searching and funneling as there is no obstacle.
+      var paths = this.astar.search(allNodes, closestNode, farthestNode);
+    } else {
+      vectors = [];
+      vectors.push(targetPosition);
+      return vectors;
+    }
 
-    var getPortalFromTo = function(a, b) {
+    var getPortalFromTo = function (a, b) {
       for (var i = 0; i < a.neighbours.length; i++) {
         if (a.neighbours[i] === b.id) {
           return a.portals[i];
@@ -214,6 +219,7 @@ var Navigation = Class.$extend({
     // We got the corridor
     // Now pull the rope
 
+    console.log(paths);
     var channel = new Channel();
 
     channel.push(startPosition);
@@ -240,7 +246,7 @@ var Navigation = Class.$extend({
 
     var vectors = [];
 
-    channel.path.forEach(function(c) {
+    channel.path.forEach(function (c) {
       var vec = new BABYLON.Vector3(c.x, c.y, c.z);
 
       // console.log(vec.clone().sub(startPosition).length());
@@ -260,13 +266,13 @@ var Navigation = Class.$extend({
     return vectors;
   },
 
-  _isPointInPoly: function(poly, pt) {
+  _isPointInPoly: function (poly, pt) {
     for (var c = false, i = -1, l = poly.length, j = l - 1; ++i < l; j = i)
       ((poly[i].z <= pt.z && pt.z < poly[j].z) || (poly[j].z <= pt.z && pt.z < poly[i].z)) && (pt.x < (poly[j].x - poly[i].x) * (pt.z - poly[i].z) / (poly[j].z - poly[i].z) + poly[i].x) && (c = !c);
     return c;
   },
 
-  _isVectorInPolygon: function(vector, polygon, vertices) {
+  _isVectorInPolygon: function (vector, polygon, vertices) {
 
     // reference point will be the centroid of the polygon
     // We need to rotate the vector as well as all the points which the polygon uses
@@ -275,7 +281,7 @@ var Navigation = Class.$extend({
 
     var polygonVertices = [];
 
-    _.each(polygon.vertexIds, function(vId) {
+    _.each(polygon.vertexIds, function (vId) {
       var point = this.getVectorFrom(vertices, vId);
       lowestPoint = Math.min(point.y, lowestPoint);
       highestPoint = Math.max(point.y, highestPoint);
@@ -289,7 +295,7 @@ var Navigation = Class.$extend({
     return false;
   },
 
-  _computeCentroids: function(geometry) {
+  _computeCentroids: function (geometry) {
     var centroids = [];
     var indices = geometry.getIndices();
     var vertices = geometry.getVerticesData(BABYLON.VertexBuffer.PositionKind);
@@ -314,16 +320,16 @@ var Navigation = Class.$extend({
   },
 
 
-  _roundNumber: function(number, decimals) {
+  _roundNumber: function (number, decimals) {
     var newnumber = new Number(number + '').toFixed(parseInt(decimals));
     return parseFloat(newnumber);
   },
 
-  _mergeVertexIds: function(aList, bList) {
+  _mergeVertexIds: function (aList, bList) {
 
     var sharedVertices = [];
 
-    aList.forEach(function(vId) {
+    aList.forEach(function (vId) {
       if (_.includes(bList, vId)) {
         sharedVertices.push(vId);
       }
@@ -346,7 +352,7 @@ var Navigation = Class.$extend({
     // Again!
     sharedVertices = [];
 
-    aList.forEach(function(vId) {
+    aList.forEach(function (vId) {
       if (_.includes(bList, vId)) {
         sharedVertices.push(vId);
       }
@@ -381,12 +387,12 @@ var Navigation = Class.$extend({
     return cList;
   },
 
-  _setPolygonCentroid: function(polygon, navigationMesh) {
+  _setPolygonCentroid: function (polygon, navigationMesh) {
     var sum = new BABYLON.Vector3(0, 0, 0);
 
     var vertices = navigationMesh.vertices;
 
-    _.each(polygon.vertexIds, function(vId) {
+    _.each(polygon.vertexIds, function (vId) {
       sum.x += vertices[vId * 3];
       sum.y += vertices[vId * 3 + 1];
       sum.z += vertices[vId * 3 + 2];
@@ -397,7 +403,7 @@ var Navigation = Class.$extend({
     polygon.centroid.copyFrom(sum);
   },
 
-  getVectorFrom: function(vertices, id, _vector) {
+  getVectorFrom: function (vertices, id, _vector) {
     if (_vector) {
       _vector.copyFromFloats(vertices[id * 3], vertices[id * 3 + 1], vertices[id * 3 + 2]);
       return _vector;
@@ -405,7 +411,7 @@ var Navigation = Class.$extend({
     return new BABYLON.Vector3(vertices[id * 3], vertices[id * 3 + 1], vertices[id * 3 + 2]);
   },
 
-  _cleanPolygon: function(polygon, navigationMesh) {
+  _cleanPolygon: function (polygon, navigationMesh) {
 
     var newVertexIds = [];
 
@@ -449,7 +455,7 @@ var Navigation = Class.$extend({
 
         // Remove the neighbours who had this vertex
         var goodNeighbours = [];
-        polygon.neighbours.forEach(function(neighbour) {
+        polygon.neighbours.forEach(function (neighbour) {
           if (!_.includes(neighbour.vertexIds, polygon.vertexIds[i])) {
             goodNeighbours.push(neighbour);
           }
@@ -472,7 +478,7 @@ var Navigation = Class.$extend({
 
   },
 
-  _isConvex: function(polygon, navigationMesh) {
+  _isConvex: function (polygon, navigationMesh) {
 
     var vertices = navigationMesh.vertices;
 
@@ -519,16 +525,16 @@ var Navigation = Class.$extend({
 
     // if ( total > (polygon.vertexIds.length-2)*Math.PI ) return false;
 
-    results.forEach(function(r) {
+    results.forEach(function (r) {
       if (r === 0) convex = false;
     });
 
     if (results[0] > 0) {
-      results.forEach(function(r) {
+      results.forEach(function (r) {
         if (r < 0) convex = false;
       });
     } else {
-      results.forEach(function(r) {
+      results.forEach(function (r) {
         if (r > 0) convex = false;
       });
     }
@@ -543,15 +549,15 @@ var Navigation = Class.$extend({
     return convex;
   },
 
-  _buildPolygonGroups: function(navigationMesh) {
+  _buildPolygonGroups: function (navigationMesh) {
 
     var polygons = navigationMesh.polygons;
 
     var polygonGroups = [];
     var groupCount = 0;
 
-    var spreadGroupId = function(polygon) {
-      _.each(polygon.neighbours, function(neighbour) {
+    var spreadGroupId = function (polygon) {
+      _.each(polygon.neighbours, function (neighbour) {
         if (_.isUndefined(neighbour.group)) {
           neighbour.group = polygon.group;
           spreadGroupId(neighbour);
@@ -559,7 +565,7 @@ var Navigation = Class.$extend({
       });
     };
 
-    _.each(polygons, function(polygon) {
+    _.each(polygons, function (polygon) {
 
       if (_.isUndefined(polygon.group)) {
         polygon.group = groupCount++;
@@ -577,7 +583,7 @@ var Navigation = Class.$extend({
     return polygonGroups;
   },
 
-  _array_intersect: function() {
+  _array_intersect: function () {
     var i, shortest, nShortest, n, len, ret = [],
       obj = {},
       nOthers;
@@ -612,7 +618,7 @@ var Navigation = Class.$extend({
     return ret;
   },
 
-  _buildPolygonNeighbours: function(polygon, navigationMesh) {
+  _buildPolygonNeighbours: function (polygon, navigationMesh) {
     polygon.neighbours = [];
 
     // All other nodes that contain at least two of our vertices are our neighbours
@@ -631,7 +637,7 @@ var Navigation = Class.$extend({
     }
   },
 
-  _buildPolygonsFromGeometry: function(geometry) {
+  _buildPolygonsFromGeometry: function (geometry) {
 
     var polygons = [];
     var vertices = geometry.getVerticesData(BABYLON.VertexBuffer.PositionKind);
@@ -663,14 +669,14 @@ var Navigation = Class.$extend({
     };
 
     // Build a list of adjacent polygons
-    _.each(polygons, function(polygon) {
+    _.each(polygons, function (polygon) {
       this._buildPolygonNeighbours(polygon, navigationMesh);
     }.bind(this));
 
     return navigationMesh;
   },
 
-  _cleanNavigationMesh: function(navigationMesh) {
+  _cleanNavigationMesh: function (navigationMesh) {
 
     var polygons = navigationMesh.polygons;
     var vertices = navigationMesh.vertices;
@@ -678,7 +684,7 @@ var Navigation = Class.$extend({
 
     // Remove steep triangles
     var up = new BABYLON.Vector3(0, 1, 0);
-    polygons = _.filter(polygons, function(polygon) {
+    polygons = _.filter(polygons, function (polygon) {
       var angle = Math.acos(BABYLON.Vector3.Dot(up, polygon.normal));
       return angle < (Math.PI / 4);
     });
@@ -692,7 +698,7 @@ var Navigation = Class.$extend({
 
     var newPolygons = [];
 
-    _.each(polygons, function(polygon) {
+    _.each(polygons, function (polygon) {
 
       if (polygon.toBeDeleted) return;
 
@@ -701,7 +707,7 @@ var Navigation = Class.$extend({
       while (keepLooking) {
         keepLooking = false;
 
-        _.each(polygon.neighbours, function(otherPolygon) {
+        _.each(polygon.neighbours, function (otherPolygon) {
 
           if (polygon === otherPolygon) return;
 
@@ -724,7 +730,7 @@ var Navigation = Class.$extend({
 
 
               // Inherit the neighbours from the to be merged polygon, except ourself
-              _.each(otherPolygon.neighbours, function(otherPolygonNeighbour) {
+              _.each(otherPolygon.neighbours, function (otherPolygonNeighbour) {
 
                 // Set this poly to be merged to be no longer our neighbour
                 otherPolygonNeighbour.neighbours = _.without(otherPolygonNeighbour.neighbours, otherPolygon);
@@ -761,9 +767,9 @@ var Navigation = Class.$extend({
 
     });
 
-    var isUsed = function(vId) {
+    var isUsed = function (vId) {
       var contains = false;
-      _.each(newPolygons, function(p) {
+      _.each(newPolygons, function (p) {
         if (!contains && _.includes(p.vertexIds, vId)) {
           contains = true;
         }
@@ -776,7 +782,7 @@ var Navigation = Class.$extend({
       if (!isUsed(i)) {
 
         // Decrement all vertices that are higher than i
-        _.each(newPolygons, function(p) {
+        _.each(newPolygons, function (p) {
           for (var j = 0; j < p.vertexIds.length; j++) {
             if (p.vertexIds[j] > i) {
               p.vertexIds[j]--;
@@ -795,7 +801,7 @@ var Navigation = Class.$extend({
 
   },
 
-  _buildNavigationMesh: function(geometry) {
+  _buildNavigationMesh: function (geometry) {
     // Prepare geometry
     this._computeCentroids(geometry);
 
@@ -815,7 +821,7 @@ var Navigation = Class.$extend({
     return navigationMesh;
   },
 
-  _mergeVertices: function(geometry) {
+  _mergeVertices: function (geometry) {
     var verticesMap = {}; // Hashmap for looking up vertices by position coordinates (and making sure they are unique)
     var unique = [],
       changes = [];
@@ -901,14 +907,14 @@ var Navigation = Class.$extend({
   },
 
 
-  _getSharedVerticesInOrder: function(a, b) {
+  _getSharedVerticesInOrder: function (a, b) {
 
     var aList = a.vertexIds;
     var bList = b.vertexIds;
 
     var sharedVertices = [];
 
-    _.each(aList, function(vId) {
+    _.each(aList, function (vId) {
       if (_.includes(bList, vId)) {
         sharedVertices.push(vId);
       }
@@ -931,7 +937,7 @@ var Navigation = Class.$extend({
     // Again!
     sharedVertices = [];
 
-    _.each(aList, function(vId) {
+    _.each(aList, function (vId) {
       if (_.includes(bList, vId)) {
         sharedVertices.push(vId);
       }
@@ -940,11 +946,11 @@ var Navigation = Class.$extend({
     return sharedVertices;
   },
 
-  _groupNavMesh: function(navigationMesh) {
+  _groupNavMesh: function (navigationMesh) {
 
     var saveObj = {};
 
-    _.each(navigationMesh.vertices, function(v) {
+    _.each(navigationMesh.vertices, function (v) {
       v = this._roundNumber(v, 2);
     }.bind(this));
 
@@ -954,28 +960,28 @@ var Navigation = Class.$extend({
 
     saveObj.groups = [];
 
-    var findPolygonIndex = function(group, p) {
+    var findPolygonIndex = function (group, p) {
       for (var i = 0; i < group.length; i++) {
         if (p === group[i]) return i;
       }
     };
 
-    _.each(groups, function(group) {
+    _.each(groups, function (group) {
 
       var newGroup = [];
 
-      _.each(group, function(p) {
+      _.each(group, function (p) {
 
         var neighbours = [];
 
-        _.each(p.neighbours, function(n) {
+        _.each(p.neighbours, function (n) {
           neighbours.push(findPolygonIndex(group, n));
         });
 
 
         // Build a portal list to each neighbour
         var portals = [];
-        _.each(p.neighbours, function(n) {
+        _.each(p.neighbours, function (n) {
           portals.push(this._getSharedVerticesInOrder(p, n));
         }.bind(this));
 

--- a/lib/Navigation.js
+++ b/lib/Navigation.js
@@ -78,7 +78,7 @@ var Navigation = Class.$extend({
 
     return _.sample(candidates) || new BABYLON.Vector3();
   },
-
+  
   projectOnNavmesh: function (position, zone, group) {
     var allNodes = this.zoneNodes[zone].groups[group];
     var vertices = this.zoneNodes[zone].vertices;
@@ -198,7 +198,7 @@ var Navigation = Class.$extend({
       var paths = this.astar.search(allNodes, startingNode, endNode);
     } else {
       vectors = [];
-      vectors.push(targetPosition);
+      vectors.push(new BABYLON.Vector3(targetPosition.x, targetPosition.y, targetPosition.z));
       return vectors;
     }
 

--- a/lib/Navigation.js
+++ b/lib/Navigation.js
@@ -18,6 +18,7 @@ var Navigation = Class.$extend({
   __init__: function () {
     this.zoneNodes = {};
     this.astar = new Astar();
+    this.yTolerance = 1;
   },
 
   buildNodes: function (mesh) {
@@ -30,6 +31,10 @@ var Navigation = Class.$extend({
 
   setZoneData: function (zone, data) {
     this.zoneNodes[zone] = data;
+  },
+
+  setHeightTolerance: function(tolerance) {
+    this.yTolerance = tolerance;
   },
 
   getGroup: function (zone, position) {
@@ -78,7 +83,7 @@ var Navigation = Class.$extend({
 
     return _.sample(candidates) || new BABYLON.Vector3();
   },
-  
+
   projectOnNavmesh: function (position, zone, group) {
     var allNodes = this.zoneNodes[zone].groups[group];
     var vertices = this.zoneNodes[zone].vertices;
@@ -281,7 +286,7 @@ var Navigation = Class.$extend({
       polygonVertices.push(point);
     }.bind(this));
 
-    if (vector.y < highestPoint + 0.5 && vector.y > lowestPoint - 0.5 &&
+    if (vector.y < highestPoint + this.yTolerance && vector.y > lowestPoint - this.yTolerance &&
       this._isPointInPoly(polygonVertices, vector)) {
       return true;
     }

--- a/lib/Navigation.js
+++ b/lib/Navigation.js
@@ -65,7 +65,7 @@ var Navigation = Class.$extend({
     var candidates = [];
 
     var polygons = this.zoneNodes[zone].groups[group];
-
+    
     _.each(polygons, function (p) {
       if (nearPosition && nearRange) {
         if (BABYLON.Vector3.DistanceSquared(nearPosition, p.centroid) < nearRange * nearRange) {
@@ -172,36 +172,30 @@ var Navigation = Class.$extend({
     var allNodes = this.zoneNodes[zone].groups[group];
     var vertices = this.zoneNodes[zone].vertices;
 
-    var closestNode = null;
-    var distance = Infinity;
+    var startingNode = null;
 
-    allNodes.forEach(function (node) {
-      var measuredDistance = BABYLON.Vector3.DistanceSquared(node.centroid, startPosition);
-      if (measuredDistance < distance && this._isVectorInPolygon(startPosition, node, vertices)) {
-        closestNode = node;
-        distance = measuredDistance;
+    for(var i = 0; i < allNodes.length; i++) {
+      if (this._isVectorInPolygon(startPosition, allNodes[i], vertices)) {
+        startingNode = allNodes[i];
+        break;
       }
-    }.bind(this));
+    }
+    
+    var endNode = null;
 
-
-    var farthestNode = null;
-    distance = Infinity;
-
-    allNodes.forEach(function (node) {
-      var measuredDistance = BABYLON.Vector3.DistanceSquared(node.centroid, targetPosition);
-      if (measuredDistance < distance && this._isVectorInPolygon(targetPosition, node, vertices)) {
-        farthestNode = node;
-        distance = measuredDistance;
+    for(var i = 0; i < allNodes.length; i++) {
+      if (this._isVectorInPolygon(targetPosition, allNodes[i], vertices)) {
+        endNode = allNodes[i];
+        break;
       }
-    }.bind(this));
-
-    // If we can't find any node, just go straight to the target
-    if (!closestNode || !farthestNode) {
+    }
+    // If we can't find any node, theres no path to target
+    if (!startingNode || !endNode) {
       return null;
     }
 
-    if (closestNode.id != farthestNode.id) { // if the starting node and target node are at the same polygon skip searching and funneling as there is no obstacle.
-      var paths = this.astar.search(allNodes, closestNode, farthestNode);
+    if (startingNode.id != endNode.id) { // if the starting node and target node are at the same polygon skip searching and funneling as there is no obstacle.
+      var paths = this.astar.search(allNodes, startingNode, endNode);
     } else {
       vectors = [];
       vectors.push(targetPosition);
@@ -219,7 +213,6 @@ var Navigation = Class.$extend({
     // We got the corridor
     // Now pull the rope
 
-    console.log(paths);
     var channel = new Channel();
 
     channel.push(startPosition);


### PR DESCRIPTION
When calling findPath, wasn't taken into account the fact that the starting and target points could be in the same polygon. This created unrealistic movements. Now the channel isn't created at all if the polygon of the starting and target points is the same thus fixing the issue.